### PR TITLE
Simplied Metadata reader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,8 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "mustangostang/spyc": "*",
         "michelf/php-markdown": "*",
-        "ext-curl": "*",
-        "eno-lang/enophp": "^0.1.3"
+        "ext-curl": "*"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master"
@@ -41,7 +39,7 @@
             "psalm --alter --issues=all",
             "@lint"
         ],
-         "lint": [
+        "lint": [
             "find . -type f -name '*.php' -print0 | xargs -0 -n1 -P4 php -l -n | (! grep -v 'No syntax errors detected' )",
             "psalm --show-info=true; exit 0",
             "phpcs"

--- a/composer.lock
+++ b/composer.lock
@@ -4,57 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "45b58ea8fd100dea853e603dcbea235f",
+    "content-hash": "b9892f199f8c22d4091142b17994fc43",
     "packages": [
-        {
-            "name": "eno-lang/enophp",
-            "version": "v0.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/eno-lang/enophp.git",
-                "reference": "ec55fbb1113cabec9c1d1f89f356d5bb499e4a79"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/eno-lang/enophp/zipball/ec55fbb1113cabec9c1d1f89f356d5bb499e4a79",
-                "reference": "ec55fbb1113cabec9c1d1f89f356d5bb499e4a79",
-                "shasum": ""
-            },
-            "require-dev": {
-                "kahlan/kahlan": "^4.3.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Eno\\": [
-                        "src",
-                        "src/elements/",
-                        "src/errors/"
-                    ],
-                    "Eno\\Errors\\": "src/errors",
-                    "Eno\\Reporters\\": "src/reporters"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Simon Repp",
-                    "email": "simon@fdpl.io",
-                    "homepage": "https://simonrepp.com"
-                }
-            ],
-            "description": "PHP library for parsing, loading and inspecting eno documents",
-            "homepage": "https://eno-lang.org/php/",
-            "keywords": [
-                "eno",
-                "parser",
-                "validation"
-            ],
-            "time": "2019-02-16T16:28:07+00:00"
-        },
         {
             "name": "michelf/php-markdown",
             "version": "1.9.0",
@@ -103,56 +54,6 @@
                 "markdown"
             ],
             "time": "2019-12-02T02:32:27+00:00"
-        },
-        {
-            "name": "mustangostang/spyc",
-            "version": "0.6.3",
-            "source": {
-                "type": "git",
-                "url": "git@github.com:mustangostang/spyc.git",
-                "reference": "4627c838b16550b666d15aeae1e5289dd5b77da0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mustangostang/spyc/zipball/4627c838b16550b666d15aeae1e5289dd5b77da0",
-                "reference": "4627c838b16550b666d15aeae1e5289dd5b77da0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.3.*@dev"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.5.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "Spyc.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "mustangostang",
-                    "email": "vlad.andersen@gmail.com"
-                }
-            ],
-            "description": "A simple YAML loader/dumper class for PHP",
-            "homepage": "https://github.com/mustangostang/spyc/",
-            "keywords": [
-                "spyc",
-                "yaml",
-                "yml"
-            ],
-            "time": "2019-09-10T13:16:29+00:00"
         }
     ],
     "packages-dev": [

--- a/src/application/ModelPost.php
+++ b/src/application/ModelPost.php
@@ -1,13 +1,12 @@
 <?php
 
-use Michelf\MarkdownExtra;
 
 class ModelPost extends Cuttlefish\Model
 {
 
     public $model = array(
-        'yaml'          => 'metadata',
-        'markdown|html' => 'content',
+        'metadatareader'    => 'metadata',
+        'markdown|html'     => 'content',
     );
 
     /**
@@ -23,12 +22,8 @@ class ModelPost extends Cuttlefish\Model
      */
     public function contents($records)
     {
-        $loaded_classes = array(
-            'mdep' => new MarkdownExtra(),
-            'spyc' => new Spyc(),
-        );
         foreach ($records as $record) {
-            $this->contents[] = $this->listContents($record, $loaded_classes);
+            $this->contents[] = $this->listContents($record);
         }
         usort($this->contents, array( $this, 'sortByPublished' ));
 

--- a/src/index.php
+++ b/src/index.php
@@ -10,4 +10,5 @@ require 'Configuration.php';
 
 define('THEME_DIR', Configuration::THEMES_FOLDER . DIRECTORY_SEPARATOR . Configuration::THEME . DIRECTORY_SEPARATOR);
 
-new Cuttlefish\App();
+$App = new Cuttlefish\App();
+$App->run();

--- a/src/system/App.php
+++ b/src/system/App.php
@@ -24,8 +24,7 @@ class App
         $this->Security    = new Security();
     }
 
-    public function __destruct()
-    {
+    public function run() {
         if ($this->Cache->is_cached) {
             return;
         }

--- a/src/system/MetadataReader.php
+++ b/src/system/MetadataReader.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Cuttlefish;
+
+
+class MetadataReader
+{
+    public function __construct()
+    {
+    }
+
+    public function loadString($subject) {
+        $data = [];
+
+        $separator = "\r\n";
+        $line = strtok($subject, $separator);
+
+        while ($line !== false) {
+            # do something with $line
+            list($key,$value) = explode(':', $line,2);
+            $data[$key] = $value;
+
+            $line = strtok( $separator );
+        }
+
+        return $data;
+    }
+}

--- a/src/system/Model.php
+++ b/src/system/Model.php
@@ -4,8 +4,9 @@ namespace Cuttlefish;
 
 use Exception;
 use Michelf\Markdown;
-use Spyc;
 use StdClass;
+use Cuttlefish\MetadataReader;
+
 
 class Model
 {
@@ -40,11 +41,10 @@ class Model
     }
 
     /**
-     * @param (Spyc|\Michelf\MarkdownExtra)[] $loaded_classes
      *
      * @return StdClass
      */
-    protected function listContents($record, array $loaded_classes): StdClass
+    protected function listContents($record): StdClass
     {
         $Content = new StdClass();
 
@@ -77,7 +77,7 @@ class Model
             $content_section         = $content_sections[ $i ];
             $section_key             = $section_keys[ $i ];
             $section_value           = $section_values[ $i ];
-            $Content->$section_value = $this->section($content_section, $section_key, $loaded_classes);
+            $Content->$section_value = $this->section($content_section, $section_key);
         }
 
         return $Content;
@@ -85,23 +85,18 @@ class Model
 
     /**
      * @param array-key $section_key
-     * @param (Spyc|\Michelf\MarkdownExtra)[] $loaded_classes
      *
      * @return StdClass
      */
-    public function section(string $content_section, $section_key, array $loaded_classes): StdClass
+    public function section(string $content_section, $section_key): StdClass
     {
-        // assign classes to their variables
-        foreach ($loaded_classes as $class_name => $obj) {
-            $$class_name = $obj;
-        }
-
         $Section = new StdClass();
         switch ($section_key) {
-            case 'yaml':
-                $yaml = Spyc::YAMLLoadString($content_section);
+            case 'metadatareader':
+                $reader = new MetadataReader();
+                $data = $reader->loadString($content_section);
 
-                foreach ($yaml as $key => $value) {
+                foreach ($data as $key => $value) {
                     $Section->$key = $value;
                 }
                 break;


### PR DESCRIPTION
Replaced YAML / ENO with simple string splitter, to remove dependencies.
Split up App method, so that the run method is called after assigning the global App variable. This makes it available in the view functions.