### PR TITLE
Add RedBean ORM

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,13 @@
     ],
     "minimum-stability": "stable",
     "require": {
-      "php": ">=7.4",
-      "michelf/php-markdown": "^1.9",
-      "vlucas/phpdotenv": "^5",
-      "ext-curl": "*",
-      "ext-simplexml": "*",
-      "ext-fileinfo": "*"
+        "php": ">=7.4",
+        "ext-curl": "*",
+        "ext-fileinfo": "*",
+        "ext-simplexml": "*",
+        "gabordemooij/redbean": "^5.7",
+        "michelf/php-markdown": "^1.9",
+        "vlucas/phpdotenv": "^5"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,53 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0573f3eb0a6b7461f3ccdc5ec7ee257",
+    "content-hash": "4101ffdf894d7aa55878a475de9cfae4",
     "packages": [
+        {
+            "name": "gabordemooij/redbean",
+            "version": "v5.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/gabordemooij/redbean.git",
+                "reference": "e31aad3b38d5c34a809381f9a5283645ce4abb29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/gabordemooij/redbean/zipball/e31aad3b38d5c34a809381f9a5283645ce4abb29",
+                "reference": "e31aad3b38d5c34a809381f9a5283645ce4abb29",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "RedBeanPHP\\": "RedBeanPHP"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Gabor de Mooij",
+                    "email": "gabor@redbeanphp.com",
+                    "homepage": "https://redbeanphp.com"
+                }
+            ],
+            "description": "RedBeanPHP ORM",
+            "homepage": "https://redbeanphp.com/",
+            "keywords": [
+                "orm"
+            ],
+            "support": {
+                "issues": "https://github.com/gabordemooij/redbean/issues",
+                "source": "https://github.com/gabordemooij/redbean/tree/v5.7"
+            },
+            "time": "2021-03-28T11:01:15+00:00"
+        },
         {
             "name": "graham-campbell/result-type",
             "version": "v1.0.1",
@@ -904,8 +949,8 @@
     "platform": {
         "php": ">=7.4",
         "ext-curl": "*",
-        "ext-simplexml": "*",
-        "ext-fileinfo": "*"
+        "ext-fileinfo": "*",
+        "ext-simplexml": "*"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
Require the powerful but simple orm RedBean.
It's not necessarily used in the Blog application but it allows more versatile applications to be created.

- [ ] Documentation
- [ ] Examples

Fixes #128 